### PR TITLE
feat: add gitlab_install_async_timeout var to prevent gitlab install from failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Gitlab timezone.
 
     gitlab_backup_keep_time: "604800"
 
+How long you want Ansible to hold ssh connection during GitLab installation task.
+
+    gitlab_install_async_timeout: 500
+
 How long to keep local backups (useful if you don't want backups to fill up your drive!).
 
     gitlab_download_validate_certs: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ gitlab_dependencies:
 # Optional settings.
 gitlab_time_zone: "UTC"
 gitlab_backup_keep_time: "604800"
+gitlab_install_async_timeout: 500
 gitlab_download_validate_certs: true
 gitlab_default_theme: '2'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   package:
     name: "{{ gitlab_package_name | default(gitlab_edition) }}"
     state: present
-  async: 300
+  async: "{{ gitlab_install_async_timeout }}"
   poll: 5
   when: not gitlab_file.stat.exists
 


### PR DESCRIPTION
Due to the fact that we had to copy our template GitLab config file before the initial installation of GitLab, GitLab configures itself using this template. Geerlingguy role has a timeout after 300 sec, which is incompatible w/ GitLab installation and configuration. 
That's the reason why we have decided to start our own fork of the role to modify this timeout. 