### PR TITLE
fix: add subjectAltName to self-cert because legacy Common Name field is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,7 @@
 - name: Create self-signed certificate.
   command: >
     openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}"
+    -addext "subjectAltName = DNS:{{ gitlab_domain }}"
     -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert


### PR DESCRIPTION
When I wanted to register a docker-runner, i had this issue: 
```
couldn't execute POST against https://*************/api/v4/runners: Post "https://***************/api/v4/runners": x509: certificate relies on legacy Common Name field, use SANs instead.
After looking for a solution, I found this fix here: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28841 
That's why I have added `-addext "subjectAltName = DNS:{{ gitlab_domain }}"`