### PR TITLE
fix: use boolean conditional for gitlab_version

### DIFF
--- a/.ansible/roles/geerlingguy.gitlab
+++ b/.ansible/roles/geerlingguy.gitlab
@@ -1,0 +1,1 @@
+/home/artybdrlt/CODE/LYDRA/Froggit/ansible-role-gitlab

--- a/.ansible/roles/geerlingguy.gitlab
+++ b/.ansible/roles/geerlingguy.gitlab
@@ -1,1 +1,0 @@
-/home/artybdrlt/CODE/LYDRA/Froggit/ansible-role-gitlab

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Define the Gitlab package name.
   set_fact:
     gitlab_package_name: "{{ gitlab_edition }}{{ gitlab_package_version_separator }}{{ gitlab_version }}"
-  when: gitlab_version | default(false)
+  when: (gitlab_version | default('')) | length > 0
 
 - name: Install GitLab
   package:


### PR DESCRIPTION
## Overview
- When I tried running the role with ansible 12, I got this error message for the task `Define the Gitlab package name.`

```
Task failed: Conditional result (True) was derived from value of type 'str' at `ansible/group_vars/all/gitlab.yml:36:17'.` Conditionals must have a boolean result.
```

With Ansible 2.19+, a when must output a genuine boolean (`True`/`False`), a empty string is refused.

 `gitlab_version | default(false) `returns the string "18.11.7-ce.0" when the variable is defined. 

